### PR TITLE
Move dependency to package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(aws_robomaker_small_house_world)
 
-find_package(ros_gz_sim REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 
 install(DIRECTORY launch models worlds maps photos param routes

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo</exec_depend>
   <exec_depend>gazebo_plugins</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
 
   <export>
    <build_type>ament_cmake</build_type>


### PR DESCRIPTION
I moved the `ros_gz_sim` dep from the `CMakeLists.txt` to the `package.xml`.

It must be in the `package.xml` because otherwise rosdep will not install it (I found the problem this way).
It does not need to be in the `CMakeLists.txt` because it is not used in the build process.

Cheers!